### PR TITLE
Gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,13 @@ AOE-exp/
 # To prevent extra Mac files from annoying people like rderekp
 **.DS_Store
 **._**
+
+# Ignore all files except for TGC files.
+/*
+!TGC/*
+!.gitattributes
+!.gitignore
+!*\ Changelog\ -\ TGC.txt
+!README-TGC.md
+!TGC\ -\ Best\ Practices.txt
+!TGC.mod


### PR DESCRIPTION
Updating .gitignore to ignore all files except for TGC files.
The purpose of this is so that the TGC repo can be in the Victoria 2 mod folder (so that people don't have to copy their changes while working all the time to test) while still being able to have other mods in the same folder (albeit as just mods, not their git repos, since the same folder can't be the home to more than one git repo).