### PR TITLE
Las Bela can't get annexed

### DIFF
--- a/TGC/events/CivilizationAndGunBoats.txt
+++ b/TGC/events/CivilizationAndGunBoats.txt
@@ -4222,6 +4222,7 @@ country_event = {
 		NOT = { tag = AFG }
 		NOT = { tag = KAL }
 		NOT = { tag = MAK }
+		NOT = { tag = LAS }
 		NOT = { tag = TRA }
 		NOT = { tag = CRL }
 		NOT = { tag = PNJ }


### PR DESCRIPTION
Las Bela could get annexed through the Doctrine of Lapse despite being a Balochi Princely State.