### PR TITLE
Industry tech changes

### DIFF
--- a/TGC/technologies/industry_tech.txt
+++ b/TGC/technologies/industry_tech.txt
@@ -651,7 +651,7 @@ hot_blast = {
 
 mechanized_mining = {
 	area = metallurgy
-	year = 1840
+	year = 1836
 	cost = 7200
 	rgo_goods_output = {
 		iron = 0.3
@@ -1062,7 +1062,7 @@ advanced_metallurgy = {
 }
 electric_furnace = {
 	area = metallurgy
-	year = 1905
+	year = 1900
 	cost = 21600
 
 	
@@ -1412,7 +1412,7 @@ medicine = {
 }
 inorganic_chemistry = {
 	area = chemistry_and_electricity
-	year = 1836
+	year = 1850
 	cost = 10800
 
 	supply_limit = 0.25
@@ -1475,7 +1475,7 @@ inorganic_chemistry = {
 }
 organic_chemistry = {
 	area = chemistry_and_electricity
-	year = 1850
+	year = 1870
 	cost = 14400
 
 	supply_limit = 0.25
@@ -1519,7 +1519,7 @@ organic_chemistry = {
 }
 electricity = {
 	area = chemistry_and_electricity
-	year = 1870
+	year = 1880
 	cost = 18000
 	
 	supply_limit = 0.50


### PR DESCRIPTION
Reverted most to HFM. Some things would just be heretical to revert, so I didn't.
These are: Regenerative furnace in 1836 and Synthetic polymers in 1919. I kept these as-is, 1850 and 1900, respectively.