### PR TITLE
Re-enable "Form Iberia" decision

### DIFF
--- a/TGC/decisions/SPA.txt
+++ b/TGC/decisions/SPA.txt
@@ -1956,10 +1956,10 @@ political_decisions = {
 				add_accepted_culture = catalan
 				add_accepted_culture = basque
 			}
-			# country_event = {
-				# id = 72751
-				# days = 0
-			# }
+			country_event = {
+				id = 72751
+				days = 0
+			}
 		}
 		ai_will_do = {
 				factor = 1


### PR DESCRIPTION
The commit https://github.com/rderekp/The-Grand-Combo/commit/6ccf5570abe8104c17e285b4cd2c85c0a7131d49
commented out the call to the event that formed Iberia as an effect of the form_iberia decision. This event seems to be working as intended from my testing, so I request that it get added back in.