### PR TITLE
Rhine crisis french victory bug fix

### DIFF
--- a/TGC/events/RhineCrisis.txt
+++ b/TGC/events/RhineCrisis.txt
@@ -90,7 +90,7 @@
 			ai_chance = { factor = 0.85 }
 		}
 
-		# TODO hidden 3rd option EVTOPTC33037 "Let’s go a step beyond that claim."
+		# TODO hidden 3rd option EVTOPTC33037 "Letâ€™s go a step beyond that claim."
 	}
 
 	#Description: Prussian response to French claims
@@ -364,6 +364,13 @@
 						NOT = { region = PRU_578 }
 					}
 					NOT = { tag = RHI }
+				}
+				FRA = {
+				    create_vassal = RHI
+				    any_owned = {
+				    limit = { is_core = RHI }
+				    secede_province = RHI
+				    }
 				}
 				country_event = 99995
 			}


### PR DESCRIPTION
Fixes a bug that make france NOT vassalize the Rhineland and give them their core provinces.