### PR TITLE
Fixing African starting setup: oob, politics, slavery

### DIFF
--- a/TGC/history/countries/BHY - Buhaya.txt
+++ b/TGC/history/countries/BHY - Buhaya.txt
@@ -1,9 +1,5 @@
 capital = 2043
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = lacustrine_bantu
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -50,5 +47,5 @@ upper_house = {
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "BHY_oob.txt"
 

--- a/TGC/history/countries/BNY - Bunyoro.txt
+++ b/TGC/history/countries/BNY - Bunyoro.txt
@@ -1,9 +1,5 @@
 capital = 2022
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = luo
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -47,8 +44,9 @@ upper_house = {
 	socialist = 0
 	communist = 0
 }
+
+set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
-
+oob = "BNY_oob.txt"

--- a/TGC/history/countries/BRD - Urundi.txt
+++ b/TGC/history/countries/BRD - Urundi.txt
@@ -24,6 +24,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = peonage
@@ -48,5 +49,5 @@ set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BRD_oob.txt"
+oob = "BRD_oob.txt"
 

--- a/TGC/history/countries/BUG - Buganda.txt
+++ b/TGC/history/countries/BUG - Buganda.txt
@@ -1,9 +1,5 @@
 capital = 2019
 primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_autocracy
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -47,8 +44,9 @@ upper_house = {
 	socialist = 0
 	communist = 0
 }
+
+set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
-
+oob = "BUG_oob.txt"

--- a/TGC/history/countries/BUH - Buha.txt
+++ b/TGC/history/countries/BUH - Buha.txt
@@ -1,9 +1,5 @@
 capital = 2046
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = lacustrine_bantu
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -50,5 +47,5 @@ upper_house = {
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "BUH_oob.txt"
 

--- a/TGC/history/countries/GON - Gonder.txt
+++ b/TGC/history/countries/GON - Gonder.txt
@@ -48,7 +48,7 @@ upper_house = {
 	communist = 0
 }
 
-# oob = "GON_oob.txt"
+oob = "GON_oob.txt"
 
 # Technologies
 # Inventions

--- a/TGC/history/countries/KAF - Kaffa.txt
+++ b/TGC/history/countries/KAF - Kaffa.txt
@@ -49,5 +49,5 @@ set_country_flag = lacking_writing_system
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "KAF_oob.txt"
+oob = "KAF_oob.txt"
 

--- a/TGC/history/countries/KGW - Karagewe.txt
+++ b/TGC/history/countries/KGW - Karagewe.txt
@@ -1,9 +1,5 @@
 capital = 2034
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = lacustrine_bantu
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -50,5 +47,5 @@ upper_house = {
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "KGW_oob.txt"
 

--- a/TGC/history/countries/KUB - Kuba.txt
+++ b/TGC/history/countries/KUB - Kuba.txt
@@ -48,5 +48,5 @@ set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "KUB_oob.txt"
+oob = "KUB_oob.txt"
 

--- a/TGC/history/countries/KZB - Kazembe.txt
+++ b/TGC/history/countries/KZB - Kazembe.txt
@@ -47,5 +47,5 @@ set_country_flag = lacking_writing_system
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "KZB_oob.txt"
+oob = "KZB_oob.txt"
 

--- a/TGC/history/countries/LBA - Luba.txt
+++ b/TGC/history/countries/LBA - Luba.txt
@@ -49,5 +49,5 @@ set_country_flag = lacking_writing_system
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "LBA_oob.txt"
+oob = "LBA_oob.txt"
 

--- a/TGC/history/countries/LUN - Lunda.txt
+++ b/TGC/history/countries/LUN - Lunda.txt
@@ -47,5 +47,5 @@ set_country_flag = lacking_writing_system
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "LUN_oob.txt"
+oob = "LUN_oob.txt"
 

--- a/TGC/history/countries/NKO - Nkore.txt
+++ b/TGC/history/countries/NKO - Nkore.txt
@@ -1,9 +1,5 @@
 capital = 2020
 primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -47,8 +44,9 @@ upper_house = {
 	socialist = 0
 	communist = 0
 }
+set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "NKO_oob.txt"
 

--- a/TGC/history/countries/RWA - Ruanda.txt
+++ b/TGC/history/countries/RWA - Ruanda.txt
@@ -23,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 # New Reforms
 conscription = no_draft
 debt_law = peonage
@@ -47,5 +48,5 @@ set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "RWA_oob.txt"
+oob = "RWA_oob.txt"
 

--- a/TGC/history/countries/SID - Sidama.txt
+++ b/TGC/history/countries/SID - Sidama.txt
@@ -47,4 +47,4 @@ set_country_flag = lacking_writing_system
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "SID_oob.txt"
+oob = "SID_oob.txt"

--- a/TGC/history/countries/TIG - Tigray.txt
+++ b/TGC/history/countries/TIG - Tigray.txt
@@ -55,4 +55,4 @@ modern_winemaking = yes
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "TIG_oob.txt"
+oob = "TIG_oob.txt"

--- a/TGC/history/countries/TOR - Tooroo.txt
+++ b/TGC/history/countries/TOR - Tooroo.txt
@@ -1,9 +1,5 @@
 capital = 2023
 primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -47,8 +44,9 @@ upper_house = {
 	socialist = 0
 	communist = 0
 }
+set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "TOR_oob.txt"
 

--- a/TGC/history/countries/UUW - Ussuwi.txt
+++ b/TGC/history/countries/UUW - Ussuwi.txt
@@ -1,9 +1,5 @@
 capital = 2047
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = lacustrine_bantu
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -50,5 +47,5 @@ upper_house = {
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "UUW_oob.txt"
 

--- a/TGC/history/countries/WAN - Wanga.txt
+++ b/TGC/history/countries/WAN - Wanga.txt
@@ -1,9 +1,5 @@
 capital = 2028
-primary_culture = baganda
-culture = luo
-culture = lacustrine_bantu
-culture = nilotic
-culture = ruanda
+primary_culture = lacustrine_bantu
 religion = animist
 government = absolute_monarchy
 plurality = 0.0
@@ -11,7 +7,7 @@ nationalvalue = nv_order
 literacy = 0.01
 non_state_culture_literacy = 0
 # Political reforms
-slavery = no_slavery
+slavery = yes_slavery
 upper_house_composition = appointed
 vote_franschise = none_voting
 public_meetings = no_meeting
@@ -27,6 +23,7 @@ health_care = no_health_care
 unemployment_subsidies = no_subsidies
 pensions = no_pensions
 school_reforms = no_schools
+
 #New Reforms
 conscription = no_draft
 debt_law = serfdom
@@ -37,7 +34,7 @@ border_policy = open_borders
 centralization = unitary
 colonial_policy = no_colonies
 set_country_flag = animist_country
-ruling_party = BUG_socialist
+ruling_party = BUG_conservative
 upper_house = {
 	fascist = 0
 	liberal = 15
@@ -47,8 +44,9 @@ upper_house = {
 	socialist = 0
 	communist = 0
 }
+set_country_flag = lacking_writing_system
 #Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
-# oob = "BUG_oob.txt"
+oob = "WAN_oob.txt"
 

--- a/TGC/history/pops/1836.1.1/Rwanda-Burundi.txt
+++ b/TGC/history/pops/1836.1.1/Rwanda-Burundi.txt
@@ -35,7 +35,12 @@
 	tribals = {
 		culture = ruanda
 		religion = animist
-		size = 113200
+		size = 99200
+	}
+	slaves = {
+		culture = ruanda
+		religion = animist
+		size = 14000
 	}
 }
 #uncolonized in 1836/ruled by kingdom of Burundi
@@ -74,6 +79,11 @@
 	tribals = {
 		culture = ruanda
 		religion = animist
-		size = 101850
+		size = 88850
+	}
+	slaves = {
+		culture = ruanda
+		religion = animist
+		size = 13000
 	}
 }

--- a/TGC/history/provinces/africa/1792 - Ziguinchor.txt
+++ b/TGC/history/provinces/africa/1792 - Ziguinchor.txt
@@ -4,4 +4,3 @@ add_core = GBU
 trade_goods = grain
 life_rating = 35
 #terrain = semidesert
-colonial = 2

--- a/TGC/history/provinces/africa/1820 - Bongor.txt
+++ b/TGC/history/provinces/africa/1820 - Bongor.txt
@@ -4,4 +4,3 @@ add_core = ADW
 trade_goods = grain
 life_rating = 10
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1821 - Abeche.txt
+++ b/TGC/history/provinces/africa/1821 - Abeche.txt
@@ -4,4 +4,3 @@ add_core = DAR
 trade_goods = grain
 life_rating = 5
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1823 - Mongo.txt
+++ b/TGC/history/provinces/africa/1823 - Mongo.txt
@@ -4,4 +4,3 @@ add_core = WAD
 trade_goods = grain
 life_rating = 10
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1824 - Mao.txt
+++ b/TGC/history/provinces/africa/1824 - Mao.txt
@@ -4,4 +4,3 @@ add_core = KBO
 trade_goods = cattle
 life_rating = 5
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1825 - Zouar.txt
+++ b/TGC/history/provinces/africa/1825 - Zouar.txt
@@ -4,4 +4,3 @@ add_core = KBO
 trade_goods = cattle
 life_rating = 5
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1827 - Khartoum.txt
+++ b/TGC/history/provinces/africa/1827 - Khartoum.txt
@@ -5,4 +5,3 @@ add_core = SUD
 trade_goods = tropical_wood
 life_rating = 35
 terrain = floodplain_farmland
-colonial = 2

--- a/TGC/history/provinces/africa/1832 - Fashoda.txt
+++ b/TGC/history/provinces/africa/1832 - Fashoda.txt
@@ -6,4 +6,3 @@ add_core = SUD
 trade_goods = grain
 life_rating = 35
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1838 - Obeid.txt
+++ b/TGC/history/provinces/africa/1838 - Obeid.txt
@@ -5,4 +5,3 @@ add_core = SUD
 trade_goods = cattle
 life_rating = 31
 #terrain = desert
-colonial = 2

--- a/TGC/history/provinces/africa/1842 - Junayah.txt
+++ b/TGC/history/provinces/africa/1842 - Junayah.txt
@@ -4,4 +4,3 @@ add_core = DAR
 trade_goods = grain
 life_rating = 10
 #terrain = semidesert
-colonial = 2

--- a/TGC/history/provinces/africa/1875 - Djibuti.txt
+++ b/TGC/history/provinces/africa/1875 - Djibuti.txt
@@ -5,4 +5,3 @@ add_core = WRL
 trade_goods = fish
 life_rating = 10
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1953 - Dikoa.txt
+++ b/TGC/history/provinces/africa/1953 - Dikoa.txt
@@ -4,4 +4,3 @@ add_core = ADW
 trade_goods = fruit
 life_rating = 10
 #terrain = semidesert
-colonial = 1

--- a/TGC/history/provinces/africa/1961 - Bamenda.txt
+++ b/TGC/history/provinces/africa/1961 - Bamenda.txt
@@ -4,4 +4,3 @@ add_core = ADW
 trade_goods = tropical_wood
 life_rating = 10
 #terrain = small_island
-colonial = 1

--- a/TGC/history/provinces/africa/1964 - Maroua.txt
+++ b/TGC/history/provinces/africa/1964 - Maroua.txt
@@ -4,4 +4,3 @@ add_core = ADW
 trade_goods = fruit
 life_rating = 10
 #terrain = small_island
-colonial = 1

--- a/TGC/history/units/ARO_oob.txt
+++ b/TGC/history/units/ARO_oob.txt
@@ -24,18 +24,21 @@ DAH = {
 }
 army = {
 	name = "Army of the Aro Confederacy"
-	location = 1935
-regiment = {
+	location = 1933
+	regiment = {
 		name= "Eze Aro's Guards"	
-	type = irregular
-	home = 1935	}
-regiment = {
+		type = irregular
+		home = 1933
+	}
+	regiment = {
 		name= "1st Ibo Warriors"	
-	type = irregular
-	home = 1935	}
-regiment = {
-		name= "2nd Ibo Warriors"		type = irregular
-	home = 1933
+		type = irregular
+		home = 1933	
+	}
+	regiment = {
+		name= "2nd Ibo Warriors"		
+		type = irregular
+		home = 1933
 	}
 }
 

--- a/TGC/history/units/ASH_oob.txt
+++ b/TGC/history/units/ASH_oob.txt
@@ -32,51 +32,38 @@ army = {
 	location = 1910
 	regiment = {
 		name= "Asantehene's Guards"
-	
-	type = cavalry
+		type = cavalry
 		home = 1910
 	}
-
 	regiment = {
 		name= "1st Ashanti Warriors"
-	
-	type = irregular
-	
-	home = 1910
+		type = irregular
+		home = 1910
 	}
 	regiment = {
 		name= "2nd Ashanti Warriors"
-	
-	type = irregular
-
+		type = irregular
 		home = 1911
 	}
 	regiment = {
 		name= "3rd Ashanti Warriors"
-	
-	type = irregular
-
+		type = irregular
 		home = 1912
 	}
 }
 
 army = {
 	name = "Accra Garrison"
-	location = 1907
+	location = 1911
 	regiment = {
 		name= "Asantehene's Guards"
-	
-	type = irregular
-
-		home = 1907
+		type = irregular
+		home = 1910
 	}
-
 	regiment = {
 		name= "1st Ashanti Warriors"
-	
-	type = irregular
-	
-	home = 1907
+		type = irregular
+		home = 1911
 	}
 }
 

--- a/TGC/history/units/AWS_oob.txt
+++ b/TGC/history/units/AWS_oob.txt
@@ -18,10 +18,10 @@ TIG = {
 }
 army = {
 	name = "Army of the Sultan of Awsa"
-	location = 1858
+	location = 1865
 	regiment = {
 		name= "Sultan's Guards"
 		type = irregular
-		home = 1858
+		home = 1865
 	}
 }

--- a/TGC/history/units/BHY_oob.txt
+++ b/TGC/history/units/BHY_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Buhaya"
+	location = 2043
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2043
+	}
+}

--- a/TGC/history/units/BNY_oob.txt
+++ b/TGC/history/units/BNY_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Bunyoro"
+	location = 2022
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2022
+	}
+}

--- a/TGC/history/units/BRD_oob.txt
+++ b/TGC/history/units/BRD_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Burundi"
+	location = 2035
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2035
+	}
+}

--- a/TGC/history/units/BUG_oob.txt
+++ b/TGC/history/units/BUG_oob.txt
@@ -1,0 +1,14 @@
+army = {
+	name = "Royal Army of Buganda"
+	location = 2019
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2019
+	}
+	regiment = {
+		name = "Bugandan Warriors"
+		type = irregular
+		home = 2019
+	}
+}

--- a/TGC/history/units/BUH_oob.txt
+++ b/TGC/history/units/BUH_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Buha"
+	location = 2046
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2046
+	}
+}

--- a/TGC/history/units/DAM_oob.txt
+++ b/TGC/history/units/DAM_oob.txt
@@ -16,19 +16,21 @@ MOS = { value = -200 }
 ASH = { value = -200 }
 army = {
 	name = "Army of the Sultanate of Damagaram"
-	location = 1815	
-regiment = {
+	location = 1952	
+	regiment = {
 		name= "Sultan's Cavalry"	
-	type = cavalry
-		home = 1815	}
-
-regiment = {
+		type = cavalry
+		home = 1952	
+	}
+	regiment = {
 		name= "1st Hausa Warriors"
 		type = irregular
-	home = 1815	}
-regiment = {
+		home = 1952	
+	}
+	regiment = {
 		name= "2nd Hausa Warriors"
 		type = irregular
-	home = 1811	}
+		home = 1952	
+	}
 }
 

--- a/TGC/history/units/DAR_oob.txt
+++ b/TGC/history/units/DAR_oob.txt
@@ -18,17 +18,17 @@ SOK = {
 }
 army = {
 	name = "Army of the Sultanate of Darfur"
-	location = 1841
+	location = 1842
 	
 	regiment = {
 		name= "Sultan's Kights"		
 		type = cavalry
-		home = 1841	
+		home = 1842	
 	}
 	regiment = {
 		name= "Fur Warriors"		
 		type = irregular
-		home = 1841	
+		home = 1842	
 	}
 }
 

--- a/TGC/history/units/ETH_oob.txt
+++ b/TGC/history/units/ETH_oob.txt
@@ -1,0 +1,21 @@
+leader = {
+   name = "Ras Gushu Zvada"
+   type = land
+   date = 1836.1.1
+   personality = heroic
+   background = school_of_defense
+}
+army = {
+    name = "Army of the Ras of Gojjam"
+    location = 1855
+    regiment = {
+        name = "Ras' Guards"
+        type = irregular
+        home = 1855
+    }
+    regiment = {
+        name = "Ras' Horsemen"
+        type = cavalry
+        home = 1855
+    }
+}

--- a/TGC/history/units/GON_oob.txt
+++ b/TGC/history/units/GON_oob.txt
@@ -1,0 +1,36 @@
+leader = {
+   name = "Ras Ali II"
+   type = land
+   date = 1836.1.1
+   background = no_background
+   personality = no_personality
+}
+army = {
+    name = "Army of the Ras"
+    location = 1852
+    regiment = {
+        name = "Ras' Guards"
+        type = irregular
+        home = 1852
+    }
+    regiment = {
+        name = "Ras' Horsemen"
+        type = cavalry
+        home = 1852
+    }
+    regiment = {
+        name = "Negus' Guards"
+        type = irregular
+        home = 1852
+    }
+    regiment = {
+        name = "Imperial Guards"
+        type = irregular
+        home = 1854
+    }
+    regiment = {
+        name = "Gonder City Guard"
+        type = irregular
+        home = 1854
+    }
+}

--- a/TGC/history/units/HAR_oob.txt
+++ b/TGC/history/units/HAR_oob.txt
@@ -28,15 +28,15 @@ leader = {
 }
 army = {
 	name = "Army of the Emir of Harar"
-	location = 1865
+	location = 1853
 	regiment = {
 		name= "Emir's Guards"
 		type = irregular
-		home = 1865
+		home = 1853
 	}
 	regiment = {
 		name= "Harari City Militia"
 		type = irregular
-		home = 1865
+		home = 1853
 	}
 }

--- a/TGC/history/units/KAF_oob.txt
+++ b/TGC/history/units/KAF_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Kaffa"
+	location = 1847
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 1847
+	}
+}

--- a/TGC/history/units/KBO_oob.txt
+++ b/TGC/history/units/KBO_oob.txt
@@ -15,26 +15,26 @@ BEN = {
 }
 army = {
 	name = "Army of the Kanem-Bornu Empire"
-	location = 1951
+	location = 1816
 	regiment = {
 		name= "1. Bornu Warriors"	
 		type = irregular
-		home = 1951
+		home = 1816
 	}
 	regiment = {
 		name= "2. Bornu Warriors"	
 		type = irregular
-		home = 1952
+		home = 1816
 	}
 	regiment = {
 		name= "3. Bornu Warriors"	
 		type = irregular
-		home = 1953
+		home = 1825
 	}
 	regiment = {
 		name= "4. Bornu Warriors"	
 		type = irregular
-		home = 1953
+		home = 1824
 	}
 }
 

--- a/TGC/history/units/KGW_oob.txt
+++ b/TGC/history/units/KGW_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Karagwe"
+	location = 2044
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2044
+	}
+}

--- a/TGC/history/units/KUB_oob.txt
+++ b/TGC/history/units/KUB_oob.txt
@@ -1,0 +1,14 @@
+army = {
+	name = "Army of the Nyim of Luba"
+	location = 1986
+	regiment = {
+		name = "Nyim's Guards"
+		type = irregular
+		home = 1986
+	}
+	regiment = {
+		name = "Kuba Warriors"
+		type = irregular
+		home = 1986
+	}
+}

--- a/TGC/history/units/KZB_oob.txt
+++ b/TGC/history/units/KZB_oob.txt
@@ -1,0 +1,14 @@
+army = {
+	name = "Army of the Mwata of Kazembe"
+	location = 2016
+	regiment = {
+		name = "Mwata's Guards"
+		type = irregular
+		home = 2016
+	}
+	regiment = {
+		name = "Kazembe Warriors"
+		type = irregular
+		home = 2016
+	}
+}

--- a/TGC/history/units/LBA_oob.txt
+++ b/TGC/history/units/LBA_oob.txt
@@ -24,22 +24,15 @@ LOA = {
 }
 army = {
 	name = "Army of the muLopwe of Luba"
-	location = 1986	
-regiment = {
-		name= "muLopwe's Guards"
+	location = 1989
+	regiment = {
+		name = "muLopwe's Guards"
 		type = irregular
-	home = 1986
+		home = 1989
 	}
-
-regiment = {
-		name= "1st Luba Warriors"
+	regiment = {
+		name = "Luba Warriors"
 		type = irregular
-	home = 1989
+		home = 1989
 	}
-
-regiment = {
-		name= "2nd Luba Warriors"
-		type = irregular
-	home = 1989	}
 }
-

--- a/TGC/history/units/LUN_oob.txt
+++ b/TGC/history/units/LUN_oob.txt
@@ -1,0 +1,19 @@
+army = {
+	name = "Army of the Mwaantayaav of Lunda"
+	location = 1988
+	regiment = {
+		name = "Mwaantayaav's Guards"
+		type = irregular
+		home = 1988
+	}
+	regiment = {
+		name = "1st Lunda Warriors"
+		type = irregular
+		home = 1988
+	}
+	regiment = {
+		name = "2nd Lunda Warriors"
+		type = irregular
+		home = 1984
+	}
+}

--- a/TGC/history/units/NKO_oob.txt
+++ b/TGC/history/units/NKO_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Nkore"
+	location = 2020
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2020
+	}
+}

--- a/TGC/history/units/OYO_oob.txt
+++ b/TGC/history/units/OYO_oob.txt
@@ -27,22 +27,21 @@ ARO = {
 }
 army = {
 	name = "Army of the Oyo Empire"
-	location = 1926
-regiment = {
+	location = 1924
+	regiment = {
 		name= "Alaafin of Oyo's Guards"		
-type = cavalry
-		
-home = 1926	}
-
-regiment = {
-		name= "1st Yoruba Warriors"	
-	type = irregular
-	home = 1924
+		type = cavalry
+		home = 1924	
 	}
-regiment = {
+	regiment = {
+		name= "1st Yoruba Warriors"	
+		type = irregular
+		home = 1923
+	}
+	regiment = {
 		name= "2nd Yoruba Warriors"		
-type = irregular
-	home = 1925
+		type = irregular
+		home = 1927
 	}
 }
 

--- a/TGC/history/units/RWA_oob.txt
+++ b/TGC/history/units/RWA_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Rwanda"
+	location = 2034
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2034
+	}
+}

--- a/TGC/history/units/SID_oob.txt
+++ b/TGC/history/units/SID_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Sidama"
+	location = 1860
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 1860
+	}
+}

--- a/TGC/history/units/SOK_oob.txt
+++ b/TGC/history/units/SOK_oob.txt
@@ -69,20 +69,20 @@ army = {
 
 army = {
 	name = "Army of the Emir of Ilorin"
-	location = 1927
+	location = 1940
 	regiment = {
 		name= "1. Yoruba"
 		type = cavalry
-		home = 1927
+		home = 1940
 	}
 	regiment = {
 		name= "6. Fulbe"
 		type = irregular
-		home = 1939
+		home = 1940
 	}
 	regiment = {
 		name= "7. Fulbe"
 		type = irregular
-		home = 1946
+		home = 1940
 	}
 }

--- a/TGC/history/units/TIG_oob.txt
+++ b/TGC/history/units/TIG_oob.txt
@@ -1,0 +1,27 @@
+leader = {
+   name = "Ras Wube Haile Mariam"
+   type = land
+   date = 1836.1.1
+   background = no_background
+   personality = no_personality
+}
+
+army = {
+    name = "Army of the Ras of Tigray"
+    location = 1856
+    regiment = {
+        name = "Ras' Guards"
+        type = irregular
+        home = 1856
+    }
+    regiment = {
+        name = "Aksum irregular"
+        type = irregular
+        home = 1856
+    }
+    regiment = {
+        name = "Antalo irregular"
+        type = irregular
+        home = 1850
+    }
+}

--- a/TGC/history/units/TOR_oob.txt
+++ b/TGC/history/units/TOR_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Tooro"
+	location = 2023
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2023
+	}
+}

--- a/TGC/history/units/TRI_oob.txt
+++ b/TGC/history/units/TRI_oob.txt
@@ -14,11 +14,11 @@ army = {
 }
 army = {
 	name = "Berbers"
-	location = 1744
+	location = 1741
 	regiment = {
 		name= "1.Imazighen"
 		type = irregular
-		home = 1744
+		home = 1741
 	}
 }
 army = {

--- a/TGC/history/units/TRZ_oob.txt
+++ b/TGC/history/units/TRZ_oob.txt
@@ -1,14 +1,14 @@
 army = {
 	name = "Army of the Emirate of Trarza"
-	location = 1775
+	location = 1776
 	regiment = {
 		name= "Emir's Guards"
 		type = irregular
-		home = 1775
+		home = 1776
 	}
 	regiment = {
 		name= "Maures Warriors"
 		type = irregular
-		home = 1777
+		home = 1778
 	}
 }

--- a/TGC/history/units/UUW_oob.txt
+++ b/TGC/history/units/UUW_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Ussuwi"
+	location = 2047
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2047
+	}
+}

--- a/TGC/history/units/WAD_oob.txt
+++ b/TGC/history/units/WAD_oob.txt
@@ -18,15 +18,16 @@ SOK = {
 }
 army = {
 	name = "Army of the Empire of Wadai"
-	location = 1821	
-regiment = {
+	location = 1823	
+	regiment = {
 		name= "Kights of Wadai"		
-	type = cavalry
-		home = 1821	}
-
-regiment = {
+		type = cavalry
+		home = 1823	
+	}
+	regiment = {
 		name= "Wadai Warriors"		
-	type = irregular
-	home = 1823	}
+		type = irregular
+		home = 1823	
+	}
 }
 

--- a/TGC/history/units/WAN_oob.txt
+++ b/TGC/history/units/WAN_oob.txt
@@ -1,0 +1,9 @@
+army = {
+	name = "Royal Army of Wanga"
+	location = 2028
+	regiment = {
+		name = "King's Guards"
+		type = irregular
+		home = 2028
+	}
+}

--- a/TGC/localisation/00_countries-demonyms.csv
+++ b/TGC/localisation/00_countries-demonyms.csv
@@ -168,6 +168,7 @@ BHP_ADJ;Punjabi;;;;;;;;;;;;;x
 BHR_ADJ;Bahraini;;;;;;;;;;;;;x
 BHT_ADJ;Bohtani;;;;;;;;;;;;;x
 BHU_ADJ;Bhutanese;Bhoutanais;Bhutanesisch;;;;;;;;;;;x
+BHY_ADJ;Buhayan;;;;;;;;;;;;;x
 BIA_ADJ;Biafran;;;;;;;;;;;;;x
 BIH_ADJ;Bihari;;;;;;;;;;;;;x
 BIK_ADJ;Bikaneri;Bikaneri;Bikaneri;;;;;;;;;;;x

--- a/TGC/localisation/00_countries-demonyms.csv
+++ b/TGC/localisation/00_countries-demonyms.csv
@@ -434,6 +434,7 @@ FSA_ADJ;American;;;;;;;;;;;;;x
 FUJ_ADJ;Fujairahi;;;;;;;;;;;x
 GAB_ADJ;Gabonese;;;;;;;;;;;;;x
 GAZ_ADJ;Nguni;;;;;;;;;;;;;x
+GBU_ADJ;Kaabuan;;;;;;;;;;;;;x
 GBU_absolute_monarchy_ADJ;Kaabuan;;;;;;;;;;;;;x
 GBU_democracy_ADJ;Bissau-Guinean;;;;;;;;;;;;;x
 GCF_ADJ;German;Deutsch;Deutsch;;;;;;;;;;;x

--- a/TGC/localisation/00_countries-names.csv
+++ b/TGC/localisation/00_countries-names.csv
@@ -88,6 +88,7 @@ BHP;Bahawalpur;;;;;;;;;;;;;x
 BHR;Bahrain;;;;;;;;;;;;;x
 BHT;Bohtan;;;;;;;;;;;;;x
 BHU;Bhutan;Bhoutan;Bhutan;;;;;;;;;;;x
+BHY;Buhaya;;;;;;;;;;;;;x
 BIA;Biafra;;;;;;;;;;;;;x
 BIH;Bihar;;;;;;;;;;;;;x
 BIK;Bikaner;Bikaner;Bikaner;;;;;;;;;;;x


### PR DESCRIPTION
The setup for most of Africa is scuffed, and while it's probably gonna get a bigger rework at some point, a lot of this stuff doesn't look like it's been touched in a few years, so I decided to give it a quick pass to make it not outright broken
- Great lakes kingdoms:
  - No longer start with socialist party in charge
  - Slavery policy added where missing, added missing slave pops to Ruanda-Urundi
  - Some missing localization added
- Basic oob for everyone
- Moving units to correct provinces for existing oobs
- Removing "colonial" province status from unciv nations
![image](https://github.com/rderekp/The-Grand-Combo/assets/5472923/60351d66-909a-4d30-a864-c4f1ce0b93bd)
