### PR TITLE
Added Southeast Asian as culture group that is allowed to have tribals.

### DIFF
--- a/TGC/events/JANFlavor.txt
+++ b/TGC/events/JANFlavor.txt
@@ -142,6 +142,7 @@ country_event = {
 							is_culture_group = southern_african
 							is_culture_group = west_african
 							is_culture_group = oceanic
+							is_culture_group = southeast_asian # Prevents MAD from losing tribals
 						}
 					}
 				}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c1072dfc-c837-49d3-9db0-1e51e39c7b85)

Original bug report above.

All I did was add 
`is_culture_group = southeast_asian`

If that is too broad, I can also specify to Malagasy only with

`has_pop_culture = malagasy`