### PR TITLE
end_of_the_uk decision is missing the rest of ENL's cores

### DIFF
--- a/TGC/decisions/ENG.txt
+++ b/TGC/decisions/ENG.txt
@@ -793,6 +793,15 @@ political_decisions = {
 			ENG_284 = { add_core = ENL }
 			ENG_291 = { add_core = ENL }
 			ENG_296 = { add_core = ENL }
+			ENG_282 = { add_core = ENL }
+			ENG_283 = { add_core = ENL }
+			ENG_281 = { add_core = ENL }
+			ENG_290 = { add_core = ENL }
+			ENG_288 = { add_core = ENL }
+			ENG_289 = { add_core = ENL }
+			ENG_292 = { add_core = ENL }
+			ENG_293 = { add_core = ENL }
+			ENG_304 = { add_core = ENL } # Isle of Man
 			517 = { add_core = ENL }
 			ENG = {
 				all_core = { remove_core = ENG }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/de254fdb-8757-4701-9a29-ae159779cdcf)

The rest of ENL's cores were missing in this decision. I added the rest of them.

The last one added is Isle of Man. I do not know if it should have the ENL core or not since it is technically not part of England. But it has no other core either (Isle of Man does not exist). So I included ENL as its core. It can be easily removed, if needed.